### PR TITLE
README.org: update yasnippet link, and change all links to https

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,8 +1,8 @@
-#+TITLE:yankpad.el [[http://melpa.org/#/yankpad][file:http://melpa.org/packages/yankpad-badge.svg]]
+#+TITLE:yankpad.el [[https://melpa.org/#/yankpad][file:https://melpa.org/packages/yankpad-badge.svg]]
 
 [[https://kungsgeten.github.io/yankpad.html][Blog post about Yankpad]]
 
-Let's say that you have text snippets that you want to paste, but that [[http://capitaomorte.github.io/yasnippet/][yasnippet]]
+Let's say that you have text snippets that you want to paste, but that [[https://joaotavora.github.io/yasnippet/][yasnippet]]
 or [[https://www.emacswiki.org/emacs/SkeletonMode][skeleton]] is a bit too much when you do not need a shortcut/abbrev for your
 snippet. You like org-mode, so why not write your snippets there? Introducing
 the yankpad:
@@ -117,7 +117,7 @@ Here's an example setup using the excellent [[https://github.com/jwiegley/use-pa
 1. Add snippet entries to your =yankpad-file=. Level 1 headings are categories and level 2 headings are snippets (by default). A quick way to open your =yankpad-file= is to use =M-x yankpad-edit=. You can also add snippets to the current =yankpad-category= by using =M-x yankpad-capture=.
 2. Insert a snippet with =M-x yankpad-insert=. If the snippet has a keyword (it starts with a word followed by a colon), you can write that keyword into the buffer and use =M-x yankpad-expand= instead. It may be useful to bind these commands to some key on your keyboard. You can also use =company-yankpad= to expand a snippet using =company-mode= (thanks [[https://github.com/sid-kurias][sid-kurias]] for contributing). If you want to insert the last snippet again, you can use =M-x yankpad-repeat= (bind that to a key if you're using it frequently).
 3. If you want to change category, use =M-x yankpad-set-category=. If you have a category with the same name as a major-mode (for instance =org-mode=), that category will be locally set when switching major-mode. In the same manner you can name a category to one of your Projectile project names (if Projectile is installed). If both cases are true, the Projectile category becomes active, but the snippets from the major mode are appended as well. If you later change category with =M-x yankpad-set-category=, the major-mode and project snippets will be appended to the chosen category.
-4. If you want to append snippets from another of your categories (basically like having two or more categories active at the same time), use =M-x yankpad-append-category=. If you want one of your categories to /always/ include snippets from another category; set the =INCLUDE= [[http://orgmode.org/manual/Property-syntax.html#Property-syntax][property]] of the category heading (several categories can be included this way, by separating them with =|=, see example at the top of this readme).
+4. If you want to append snippets from another of your categories (basically like having two or more categories active at the same time), use =M-x yankpad-append-category=. If you want one of your categories to /always/ include snippets from another category; set the =INCLUDE= [[https://orgmode.org/manual/Property-syntax.html#Property-syntax][property]] of the category heading (several categories can be included this way, by separating them with =|=, see example at the top of this readme).
 5. To quickly open your =yankpad-file= for editing, run =M-x yankpad-edit=.
 6. Yankpad caches your snippets, making it a bit snappier to insert snippets from the yankpad. If you've edited your =yankpad-file= you might want to use =M-x yankpad-reload= to clear the snippet cache and reload your snippets in the current category.
 
@@ -143,7 +143,7 @@ Snippets in your Yankpad can have tags, and some of these have special meanings:
 - =<key>= :: The last tag of a snippet (except if its one of the above) will add the tag as a keybinding when first calling =yankpad-map=. If the last tag is =o=, then using =M-x yankpad-map o= will insert that snippet. This is most useful if you bind =yankpad-map= to a key.
 * Changelog
 - 1.70 (February 2017) :: =yankpad-repeat= and =yankpad-capture-snippet= added.
-- 1.60 (January 2017) :: =company-yankpad= (requires [[http://company-mode.github.io/][company-mode]]) was contributed by [[https://github.com/sid-kurias][sid-kurias]]. You can now use company to complete snippet names!
+- 1.60 (January 2017) :: =company-yankpad= (requires [[https://company-mode.github.io/][company-mode]]) was contributed by [[https://github.com/sid-kurias][sid-kurias]]. You can now use company to complete snippet names!
 - 1.51 (January 2017) :: Added =yankpad-reload=.
 - 1.50 (September 2016) :: It is now possible to have active snippets from several categories at once, by using =M-x yankpad-append-category= or by modifying the yankpad file. This is done automatically for major mode and projectile categories.
 - 1.40 (August 2016) :: Added =results= tag. Works as =func= tag, but the output of the function is inserted into the buffer.


### PR DESCRIPTION
PS The "different sets" of snippets you describe in your [blog post](https://kungsgeten.github.io/yankpad.html) could be implemented in yasnippet using the [condition system](https://joaotavora.github.io/yasnippet/snippet-expansion.html#sec-2-2), though the convenience of having all the snippets laid out in a single file is something that's really lacking.