### PR TITLE
Display help with yankpad-map

### DIFF
--- a/yankpad.el
+++ b/yankpad.el
@@ -442,7 +442,7 @@ Each snippet is a list (NAME TAGS SRC-BLOCKS TEXT)."
                (apply 'concat (mapcar 'cdr (sort yankpad-map-help
                                                  (lambda (x y)
                                                    (string-lessp (car x) (car y))))))
-             (format "nothing is defined" yankpad-category)))
+             (format "nothing is defined in %s" yankpad-category)))
   (set-transient-map 'yankpad-keymap))
 
 (defvar yankpad-map-help nil "Alist of key and title used in `yankpad-map'.")


### PR DESCRIPTION
This patch makes `yankpad-map` display a tiny help on snippet keys. Please feel free to merge it if you'd find it useful. 

Note: The list is sorted in a lexicographical order of keys. Upper case keys take precedence over lower case ones. To change this order, you have to use a comparison function other than `string-lessp`. 