### PR TITLE
Parse entry to get src-blocks from text

### DIFF
--- a/yankpad.el
+++ b/yankpad.el
@@ -505,7 +505,9 @@ removed from the snippet text."
         (let* ((text (substring-no-properties (org-remove-indentation (org-get-entry))))
                (tags (org-get-tags))
                (src-blocks (when (member "src" tags)
-                             (org-element-map (org-element-at-point) 'src-block #'identity))))
+			     (org-element-map 
+				 (with-temp-buffer (insert text) (org-element-parse-buffer))
+				 'src-block #'identity))))
           (when remove-props
             (setq text (string-trim-left
                         (replace-regexp-in-string org-property-drawer-re "" text))))


### PR DESCRIPTION
When I used the src tag to use a snippet with source code, I found that the begin_src, end_src lines were in the inserted snippet. When I debugged the code I found that org-element-map was being called with point on a heading and this only picks up the heading itself, not the entry for the heading. Consequently, the call to org-element-map to collect src-blocks does not find any such blocks.

Clearly, yankpad assumes org-get-entry will pick up the full text of an entry. I modified the code to parse this text to get the source blocks. 