### PR TITLE
Make yankpad-file and yankpad-default-category customizable

### DIFF
--- a/yankpad.el
+++ b/yankpad.el
@@ -154,8 +154,10 @@
   "The current yankpad category.  Change with `yankpad-set-category'.")
 (put 'yankpad-category 'safe-local-variable #'string-or-null-p)
 
-(defvar yankpad-default-category "Default"
-  "Used as fallback if no category is found when running `yankpad-local-category-to-major-mode'.")
+(defcustom yankpad-default-category "Default"
+  "Used as fallback if no category is found when running `yankpad-local-category-to-major-mode'."
+  :type 'string
+  :group 'yankpad)
 
 (defvar yankpad-category-heading-level 1
   "The `org-mode' heading level of categories in the `yankpad-file'.")

--- a/yankpad.el
+++ b/yankpad.el
@@ -141,8 +141,14 @@
 (when (version< (org-version) "8.3")
   (require 'ox))
 
-(defvar yankpad-file (expand-file-name "yankpad.org" org-directory)
-  "The path to your yankpad.")
+(defgroup yankpad nil
+  "Paste snippets from an org-mode file."
+  :group 'editing)
+
+(defcustom yankpad-file (expand-file-name "yankpad.org" org-directory)
+  "The path to your yankpad."
+  :type 'string
+  :group 'yankpad)
 
 (defvar yankpad-category nil
   "The current yankpad category.  Change with `yankpad-set-category'.")


### PR DESCRIPTION
Emacs customization system is useful. It lets the user configure variables interactively, and the user can choose whether or not to persist settings in `custom-file`. I keep local settings in `custom-file`, while maintaining global settings in my public repository.

Now I want to use yankpad at work, and its `yankpad-file` must be local, so I have to configure `yankpad-file` as a custom variable. I have implemented it.

Optionally, you may want to add `:set` property to `yankpad-file`, so that snippets are reloaded after `yankpad-file` is changed.

`yankpad-default-category` usually doesn't have to be customizable, but some non-English-speaking users may prefer a category name in their own locale, so it would be slightly better to make it explicitly customizable.