### PR TITLE
Use cl-case instead of case

### DIFF
--- a/yankpad.el
+++ b/yankpad.el
@@ -735,7 +735,7 @@ FN is the function that will extract either name or key."
   "Company backend for yankpad."
   (interactive (list 'interactive))
   (if (require 'company nil t)
-      (case command
+      (cl-case command
         (interactive (company-begin-backend 'company-yankpad))
         (prefix (company-grab-symbol))
         (annotation (car (company-yankpad--name-or-key


### PR DESCRIPTION
Hi.

`case` is treated as an undefined function in byte compiling if cl.el is not loaded.
And it causes "Symbol’s function definition is void: prefix" error.

I think this is related to #35 .