### PR TITLE
Expand snippet even if the snippet is a suffix of the current symbol

### DIFF
--- a/yankpad.el
+++ b/yankpad.el
@@ -473,9 +473,11 @@ Does not change `yankpad-category'."
   "Get current keyword and its bounds."
   (save-excursion
     (let (beg (end (point)))
-      (when (re-search-forward "[[:space:]]" nil t -1)
-        (setq beg (1+ (point)))
-        (cons (buffer-substring beg end) (cons beg end))))))
+      (when (re-search-backward "\\([[:blank:]\n]\\|^\\)" nil t 1)
+        (setq beg (if (bolp)
+                      (point)
+                    (1+ (point))))
+        (cons (buffer-substring-no-properties beg end) (cons beg end))))))
 
 ;;;###autoload
 (defun yankpad-expand (&optional _first)

--- a/yankpad.el
+++ b/yankpad.el
@@ -536,7 +536,7 @@ This function can be added to `hippie-expand-try-functions-list'."
                                 possible-snippets ""))
                  (snippet (cdr snippet-info))
                  (snippet-keyword (car snippet-info)))
-            (delete-region (+ (- (cdr bounds) (length snippet-keyword))) (cdr bounds))
+            (delete-region (- (cdr bounds) (length snippet-keyword)) (cdr bounds))
             (yankpad--run-snippet (cdr snippet-info))
             (throw 'loop snippet)))
         nil))))

--- a/yankpad.el
+++ b/yankpad.el
@@ -469,7 +469,6 @@ Does not change `yankpad-category'."
       (message (concat "No snippet named " name))
       nil)))
 
-
 (defun yankpad-keyword-with-bounds-at-point ()
   "Get current keyword and its bounds."
   (save-excursion
@@ -493,6 +492,7 @@ This function can be added to `hippie-expand-try-functions-list'."
          (symbol (car symbol-with-bounds))
          (bounds (cdr symbol-with-bounds))
          (snippet-prefix (concat symbol yankpad-expand-separator))
+         (possible-snippets '())
          (case-fold-search nil))
     (when (and symbol yankpad-category)
       (catch 'loop
@@ -511,13 +511,32 @@ This function can be added to `hippie-expand-try-functions-list'."
                    (delete-region (car bounds) (cdr bounds))
                    (yankpad--run-snippet snippet)
                    (throw 'loop snippet)))
+
              ;; Otherwise look for expand keyword
              (when (string-prefix-p snippet-prefix
                                     (car (split-string (car snippet) " ")))
                (delete-region (car bounds) (cdr bounds))
                (yankpad--run-snippet snippet)
-               (throw 'loop snippet))))
+               (throw 'loop snippet))
+
+             ;; Collect suffix matches
+             (let ((snippet-keyword (car (split-string (car snippet) yankpad-expand-separator))))
+               (when (string-suffix-p snippet-keyword symbol)
+                 (add-to-list 'possible-snippets (cons snippet-keyword snippet))))))
          (yankpad-active-snippets))
+
+        ;; Find the longest suffix match and apply it, if we have one
+        (when possible-snippets
+          (let* ((snippet-info (seq-reduce
+                                (lambda (acc it)
+                                  (if (> (length (car it)) (length acc))
+                                      it acc))
+                                possible-snippets ""))
+                 (snippet (cdr snippet-info))
+                 (snippet-keyword (car snippet-info)))
+            (delete-region (+ (- (cdr bounds) (length snippet-keyword))) (cdr bounds))
+            (yankpad--run-snippet (cdr snippet-info))
+            (throw 'loop snippet)))
         nil))))
 
 ;;;###autoload


### PR DESCRIPTION
Assume that I have a snippet named `today` that expands to current
date, like `2021-07-16 Fri`. Assuming `|` denotes the cursor, observe
the following expansions:

```
Sample text today| -> Sample text 2021-07-16 Fri
today| -> today
[today|] -> [today]
```

As you can see, the second and third one does not behave as
expected. Second one happens due to some regression introduced in #73.
Third one was never working, because yasnippet is looking for a
keyword named `[today`. This commit makes them expand as expected:

```
today| -> 2021-07-16 Fri
[today|] -> [2021-07-16 Fri]
```

This also works for following scenarios:

```
aaaatoday| -> aaaa2021-07-16 Fri
```

Assume that you have another snippet with keyword `totoday` along with
the `today` snippet. When you try to expand `aaaatotoday|`, then
`totoday` snippet will be expanded instead of the `today` snippet. The
longest matching snippet wins.

---

Let me know if there are cases that is is not the wanted behavior.